### PR TITLE
Add pyyaml dependency to cmake-format hook, required if .cmake-format.yaml is present

### DIFF
--- a/precommend/.pre-commit-config.yaml
+++ b/precommend/.pre-commit-config.yaml
@@ -54,6 +54,8 @@ repos:
     hooks:
       # Apply formatting to CMake files
       - id: cmake-format
+        additional_dependencies:
+        - pyyaml
       # Apply linting to CMake files
       - id: cmake-lint
 


### PR DESCRIPTION
- resolves #12
