### PR TITLE
Limit clang-format to c/c++/cuda types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     rev: v18.1.1
     hooks:
       - id: clang-format  # Format C++ code with Clang-Format - automatically applying the changes
+        types_or: [c++, c, cuda]
         args:
         - --style=Mozilla
 


### PR DESCRIPTION
- as done in https://github.com/ssciwr/clang-format-wheel pre-commit example
- implicit default value of `types_or` is `[c++, c, c#, cuda, java, javascript, json, objective-c, proto, textproto]`
- some of these, in particular javascript and json, can interfere with other hooks
